### PR TITLE
Properly capture usernames

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -540,7 +540,7 @@ export class Client {
 		case 'J': {
 			const messageArguments: IClientMessageTypes['join'] = {
 				rank: messageParts[0].charAt(0),
-				usernameText: messageParts[0].substr(1),
+				usernameText: messageParts[0].substr(1).split('@')[0],
 			};
 			const {away, status, username} = Tools.parseUsernameText(messageArguments.usernameText);
 			const user = Users.add(username);
@@ -564,7 +564,7 @@ export class Client {
 		case 'L': {
 			const messageArguments: IClientMessageTypes['leave'] = {
 				rank: messageParts[0].charAt(0),
-				usernameText: messageParts[0].substr(1),
+				usernameText: messageParts[0].substr(1).split('@')[0],
 			};
 			const {away, status, username} = Tools.parseUsernameText(messageArguments.usernameText);
 			const user = Users.add(username);
@@ -591,7 +591,7 @@ export class Client {
 		case 'N': {
 			const messageArguments: IClientMessageTypes['name'] = {
 				rank: messageParts[0].charAt(0),
-				usernameText: messageParts[0].substr(1),
+				usernameText: messageParts[0].substr(1).split('@')[0],
 				oldId: messageParts[1],
 			};
 			const {away, status, username} = Tools.parseUsernameText(messageArguments.usernameText);

--- a/src/client.ts
+++ b/src/client.ts
@@ -512,7 +512,7 @@ export class Client {
 				const users = messageArguments.userlist.split(",");
 				for (let i = 1; i < users.length; i++) {
 					const rank = users[i].charAt(0);
-					const {away, status, username} = Tools.parseUsernameText(users[i].substr(1));
+					const {away, status, username} = Tools.parseUsernameText(users[i].substr(1).split('@')[0]);
 					const user = Users.add(username);
 					room.users.add(user);
 					if (status || user.status) user.status = status;


### PR DESCRIPTION
Right now, Lady Monita/Lanette is broken because it's reading the protocol and attaching the user's status to their username. This fix drops the status from the username in 'n', 'l', and 'j' messages.