### PR TITLE
minimize board html

### DIFF
--- a/src/games/templates/board-property.ts
+++ b/src/games/templates/board-property.ts
@@ -278,9 +278,7 @@ export abstract class BoardPropertyGame<BoardSpaces = Dict<BoardSpace>> extends 
 
 	getSpaceHtml(side: BoardSide, space: number, playerLocations: KeyedDict<BoardSide, Dict<Player[]>>): string {
 		const boardSpace = this.board[side][space];
-		const isBottom = side === 'bottomRow' || (space === 9 && side === 'rightColumn') || (space === 0 && side === 'leftColumn');
-		let html = '<td style=background:' + Tools.hexColorCodes[boardSpace.color]["background-color"] +
-			+ (isBottom ? 'height:20px' : '') + '>';
+		let html = "<td style='background: " + Tools.hexColorCodes[boardSpace.color]["background-color"] + "'>";
 		if (playerLocations[side][space]) {
 			html += (playerLocations[side][space].length > 1 ? "*" : this.playerLetters.get(playerLocations[side][space][0]));
 		} else if (boardSpace instanceof BoardPropertySpace && boardSpace.owner) {

--- a/src/games/templates/board-property.ts
+++ b/src/games/templates/board-property.ts
@@ -278,13 +278,12 @@ export abstract class BoardPropertyGame<BoardSpaces = Dict<BoardSpace>> extends 
 
 	getSpaceHtml(side: BoardSide, space: number, playerLocations: KeyedDict<BoardSide, Dict<Player[]>>): string {
 		const boardSpace = this.board[side][space];
-		let html = '<td style=background-color:' + Tools.hexColorCodes[boardSpace.color]["background-color"] +
-			' width="20px" height="20px"; align="center">';
+		let html = '<td style=background:' + Tools.hexColorCodes[boardSpace.color]["background-color"] +
+			+ (side === 'bottomRow' || space === 0 ? 'height:20px' : '') + '>';
 		if (playerLocations[side][space]) {
-			html += "<b>" + (playerLocations[side][space].length > 1 ? "*" : this.playerLetters.get(playerLocations[side][space][0])) +
-				"</b>";
+			html += (playerLocations[side][space].length > 1 ? "*" : this.playerLetters.get(playerLocations[side][space][0]));
 		} else if (boardSpace instanceof BoardPropertySpace && boardSpace.owner) {
-			html += "<b>" + this.playerLetters.get(boardSpace.owner)!.toLowerCase() + "</b>";
+			html += this.playerLetters.get(boardSpace.owner)!.toLowerCase();
 		}
 		html += "</td>";
 

--- a/src/games/templates/board-property.ts
+++ b/src/games/templates/board-property.ts
@@ -278,8 +278,9 @@ export abstract class BoardPropertyGame<BoardSpaces = Dict<BoardSpace>> extends 
 
 	getSpaceHtml(side: BoardSide, space: number, playerLocations: KeyedDict<BoardSide, Dict<Player[]>>): string {
 		const boardSpace = this.board[side][space];
+		const isBottom = side === 'bottomRow' || (space === 9 && side === 'rightColumn') || (space === 0 && side === 'leftColumn');
 		let html = '<td style=background:' + Tools.hexColorCodes[boardSpace.color]["background-color"] +
-			+ (side === 'bottomRow' || space === 0 ? 'height:20px' : '') + '>';
+			+ (isBottom ? 'height:20px' : '') + '>';
 		if (playerLocations[side][space]) {
 			html += (playerLocations[side][space].length > 1 ? "*" : this.playerLetters.get(playerLocations[side][space][0]));
 		} else if (boardSpace instanceof BoardPropertySpace && boardSpace.owner) {

--- a/src/games/templates/board.ts
+++ b/src/games/templates/board.ts
@@ -80,9 +80,11 @@ export abstract class BoardGame extends Game {
 		const topCorner = this.board.leftColumn.length - 1;
 		const rightColumnOffset = this.board.rightColumn.length - 1;
 
-		let html = '<div class="infobox"><b><font color="black"><table align="center"; border="2"; style=text-align:center>';
+		let html = '<div class="infobox"><table align="center" border="2" ' +
+			'style="color: black;font-weight: bold;text-align: center;table-layout: fixed;width: ' +
+			(25 * (this.board.topRow.length + 2)) + 'px">';
 		for (let i = this.board.leftColumn.length - 1; i >= 0; i--) {
-			html += "<tr style=height:24px>";
+			html += "<tr style='height:25px'>";
 			html += this.getSpaceHtml('leftColumn', i, playerLocations);
 			if (i === topCorner) {
 				for (let i = 0; i < this.board.topRow.length; i++) {
@@ -100,7 +102,7 @@ export abstract class BoardGame extends Game {
 			html += this.getSpaceHtml('rightColumn', rightColumnOffset - i, playerLocations);
 			html += "</tr>";
 		}
-		html += "</table></font></b></div>";
+		html += "</table></div>";
 
 		this.sayUhtml(this.uhtmlBaseName + '-board', html);
 	}

--- a/src/games/templates/board.ts
+++ b/src/games/templates/board.ts
@@ -80,7 +80,7 @@ export abstract class BoardGame extends Game {
 		const topCorner = this.board.leftColumn.length - 1;
 		const rightColumnOffset = this.board.rightColumn.length - 1;
 
-		let html = '<b><div class="infobox"><font color="black"><table align="center"; border="2">';
+		let html = '<div class="infobox"><b><font color="black"><table align="center"; border="2"; style=text-align:center>';
 		for (let i = this.board.leftColumn.length - 1; i >= 0; i--) {
 			html += "<tr style=height:24px>";
 			html += this.getSpaceHtml('leftColumn', i, playerLocations);

--- a/src/games/templates/board.ts
+++ b/src/games/templates/board.ts
@@ -80,9 +80,9 @@ export abstract class BoardGame extends Game {
 		const topCorner = this.board.leftColumn.length - 1;
 		const rightColumnOffset = this.board.rightColumn.length - 1;
 
-		let html = '<div class="infobox"><font color="black"><table align="center"; border="2">';
+		let html = '<b><div class="infobox"><font color="black"><table align="center"; border="2">';
 		for (let i = this.board.leftColumn.length - 1; i >= 0; i--) {
-			html += "<tr>";
+			html += "<tr style=height:24px>";
 			html += this.getSpaceHtml('leftColumn', i, playerLocations);
 			if (i === topCorner) {
 				for (let i = 0; i < this.board.topRow.length; i++) {
@@ -100,7 +100,7 @@ export abstract class BoardGame extends Game {
 			html += this.getSpaceHtml('rightColumn', rightColumnOffset - i, playerLocations);
 			html += "</tr>";
 		}
-		html += "</table></font></div>";
+		html += "</table></font></b></div>";
 
 		this.sayUhtml(this.uhtmlBaseName + '-board', html);
 	}


### PR DESCRIPTION
I noticed the html used for boards in Lanette is pretty long, making it take more data from users, send slower, and take up more space in roomlogs. I've spent a lot of time on this very thing in Battle Dome, and figured I could make a difference here too :)
Essentially what I've done is:
- Move the width attribute to the bottom cells only (the others will adapt)
- Move height attribute to only the `<tr>` tags
- Set text alignment and bold on the table rather than each relevant cell
- Changed `background-color` to `background` because HTML doesn't actually care which you use

This takes the final HTML produced from about 4200 characters to about 2700 characters.

Note: I didn't get a chance to test this, and I've got no amount of typescript knowledge, so be sure to give this a test before merging and running the code.
(also I'm Felucia on PS if you want to talk)