### PR TITLE
Map currency games: Display a control panel to latejoiners

### DIFF
--- a/src/games/templates/map-currency.ts
+++ b/src/games/templates/map-currency.ts
@@ -20,6 +20,7 @@ export abstract class MapCurrencyGame extends MapGame {
 	onAddPlayer(player: Player, lateJoin?: boolean): boolean {
 		if (lateJoin) {
 			this.positionPlayer(player);
+            this.sendPlayerControls(player);
 		}
 		this.lives.set(player, this.startingLives);
 		return true;


### PR DESCRIPTION
In Persian's Garden, latejoiners can't see the control panel (but can use commands). This PR make it viable.