### PR TITLE
User hosted game: add missing arguments to .timer on .store

### DIFF
--- a/src/commands/user-hosted-game.ts
+++ b/src/commands/user-hosted-game.ts
@@ -1283,7 +1283,10 @@ export const commands: BaseCommandDefinitions = {
 				}
 				if (CommandParser.isCommandMessage(gameRoom.userHostedGame.storedMessages[key])) {
 					const parts = gameRoom.userHostedGame.storedMessages[key].split(" ");
-					this.run(parts[0].substr(1), parts.slice(1).join(" "));
+                    let storedCommand = Tools.toId(parts[0].substr(1));
+
+                    if (storedCommand === "timer") storedCommand = "gametimer";
+					this.run(storedCommand, parts.slice(1).join(" "));
 					return;
 				}
 				this.say(gameRoom.userHostedGame.storedMessages[key]);


### PR DESCRIPTION
Non-auth hosts can't use .timer command in .store, this PR is fixing that problem.