### PR TITLE
Official Tournament Scheduler: Don't spam with tournament creation

### DIFF
--- a/src/html-pages/official-tournament-scheduler.ts
+++ b/src/html-pages/official-tournament-scheduler.ts
@@ -285,6 +285,8 @@ class OfficialTournamentScheduler extends HtmlPageBase {
 		if (!this.canCreateTournament) return;
 
 		const database = this.getDatabase();
+		const numericMonth = parseInt(month);
+		month = numericMonth.toString();
 		if (month in database.officialTournamentSchedule!.years[this.selectedYear].months) {
 			this.newMonthInput.parentSetErrors(["A schedule already exists for " + month + "/" + this.selectedYear]);
 			this.send();
@@ -297,7 +299,7 @@ class OfficialTournamentScheduler extends HtmlPageBase {
 
 		const date = new Date();
 		date.setFullYear(this.selectedYear);
-		date.setMonth(parseInt(month) - 1, 1);
+		date.setMonth(numericMonth - 1, 1);
 		const lastDayOfNewMonth = Tools.getLastDayOfMonth(date);
 
 		const days: Dict<ITournamentScheduleDay> = {};

--- a/src/tournaments.ts
+++ b/src/tournaments.ts
@@ -733,7 +733,7 @@ export class Tournaments {
 		let nextOfficialIndex = -1;
 
 		for (let i = 0; i < this.officialTournaments[room.id].length; i++) {
-			if (this.officialTournaments[room.id][i].time >= now) {
+			if (this.officialTournaments[room.id][i].time >= now && (this.officialTournaments[room.id][i].time - now) < 2_147_483_647) {
 				nextOfficialIndex = i;
 				break;
 			}


### PR DESCRIPTION
Changes from `src/html-pages/official-tournament-scheduler.ts`:
・ Disallow non-integer inputs
・ Convert strings with numbers to pure integers

Changes from `src/tournaments.ts`:
・ Ignore schedules if it beyond the upper limit of `setTimeout()`. Without this, the input for setTimeout will be 1000.