### PR TITLE
Measurements: Remove "undefind" if the message was global one

### DIFF
--- a/src/client/websocket.ts
+++ b/src/client/websocket.ts
@@ -288,8 +288,11 @@ export class Websocket {
 				}
 
 				this.outgoingMessageMeasurements.unshift(measurement);
-				this.outgoingMessageMeasurementsInfo.unshift(measurement + " (" + this.lastOutgoingMessage.type + " in " +
-					(this.lastOutgoingMessage.roomid || this.lastOutgoingMessage.userid) + ")");
+				this.outgoingMessageMeasurementsInfo.unshift(measurement + " (" + this.lastOutgoingMessage.type +
+					((this.lastOutgoingMessage.roomid || this.lastOutgoingMessage.userid)
+						? (" in " + (this.lastOutgoingMessage.roomid || this.lastOutgoingMessage.userid))
+						: "")
+				+ ")");
 
 				this.lastMeasuredMessage = this.lastOutgoingMessage;
 				this.lastProcessingTimeCheck = responseTime;


### PR DESCRIPTION
This commit removes undefined in outgoing message measurements.
```diff
- Outgoing message measurements: [178 (query-rooms in undefined), 180 (trn in undefined)]
+ Outgoing message measurements: [174 (query-rooms), 176 (trn)]
```
