### PR TITLE
Add all-answers, solo and team achievements for QuestionAndAnswer type games

### DIFF
--- a/src/games/ambipoms-tossups.ts
+++ b/src/games/ambipoms-tossups.ts
@@ -1,12 +1,20 @@
 import type { Player } from "../room-activity";
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
 const MAX_LETTERS = 18;
 
+type AchievementNames = "untossable" | "captainuntossable";
+
 class AmbipomsTossups extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"untossable": {name: "Untossable", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainuntossable": {name: "Captain Untossable", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = AmbipomsTossups.achievements.untossable;
+	allAnswersTeamAchievement =  AmbipomsTossups.achievements.captainuntossable;
 	currentCategory: string = '';
 	hints: string[] = [];
 	hintUpdates: number = 0;

--- a/src/games/azelfs-alliteration.ts
+++ b/src/games/azelfs-alliteration.ts
@@ -1,9 +1,18 @@
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from "./templates/question-and-answer";
 
+type AchievementNames = "adeptalliterator" | "adeptcaptainalliterator";
+
 class AzelfsAlliteration extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"adeptalliterator": {name: "Adept Alliterator", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"adeptcaptainalliterator": {name: "Adept Captain Alliterator", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = AzelfsAlliteration.achievements.adeptalliterator;
+	allAnswersTeamAchievement =  AzelfsAlliteration.achievements.adeptcaptainalliterator;
 	currentCategory: string = '';
 
 	static async loadData(): Promise<void> { // eslint-disable-line @typescript-eslint/require-await

--- a/src/games/chimechos-stat-school.ts
+++ b/src/games/chimechos-stat-school.ts
@@ -1,9 +1,19 @@
 import type { Player } from "../room-activity";
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
+type AchievementNames = "firststatesman" | "firstcaptainstatesman";
+
 class ChimechosStatSchool extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"firststatesman": {name: "First Statesman", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"firstcaptainstatesman": {name: "First Captain Statesman", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
+
+	allAnswersAchievement = ChimechosStatSchool.achievements.firststatesman;
+	allAnswersTeamAchievement = ChimechosStatSchool.achievements.firstcaptainstatesman;
 
 	hintPrefix: string = "Randomly generated base stats";
 	oneGuessPerHint = true;

--- a/src/games/deoxys-differences.ts
+++ b/src/games/deoxys-differences.ts
@@ -1,6 +1,6 @@
 import type { Player } from "../room-activity";
 import type { ModelGeneration, IGifDirectionData } from "../types/dex";
-import type { IGameFile } from "../types/games";
+import type { IGameAchievement, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from "./templates/question-and-answer";
 
 const MIN_POKEMON = 3;
@@ -22,7 +22,17 @@ const data: {pokemon: string[], gifData: Dict<IGifDirectionData>} = {
 	gifData: {},
 };
 
+type AchievementNames = "deoxysspeed" | "deoxyscaptainspeed";
+
 class DeoxysDifferences extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"deoxysspeed": {name: "Deoxys Speed", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"deoxyscaptainspeed": {name: "Deoxys Captain Speed", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
+	
+	allAnswersAchievement = DeoxysDifferences.achievements.deoxysspeed;
+	allAnswersTeamAchievement = DeoxysDifferences.achievements.deoxyscaptainspeed;
 	answerCommands: string[] = [answerCommand];
 	cooldownBetweenRounds: number = 5 * 1000;
 	differenceCoordinates: [number, number] | null = null;

--- a/src/games/eevees-evolutionary-lines.ts
+++ b/src/games/eevees-evolutionary-lines.ts
@@ -1,10 +1,20 @@
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
 const HIDDEN_POKEMON = "______";
 
+type AchievementNames = "darwinner" | "captaindarwinner";
+
 class EeveesEvolutionaryLines extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"darwinner": {name: "Darwinner", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captaindarwinner": {name: "Captain Darwinner", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
+
+	allAnswersAchievement = EeveesEvolutionaryLines.achievements.darwinner;
+	allAnswersTeamAchievement =  EeveesEvolutionaryLines.achievements.captaindarwinner;
 
 	static async loadData(): Promise<void> { // eslint-disable-line @typescript-eslint/require-await
 		const hints: Dict<string[]> = {};

--- a/src/games/elgyems-number-encoder.ts
+++ b/src/games/elgyems-number-encoder.ts
@@ -1,4 +1,4 @@
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
 const upperCaseLetters = Tools.letters.toUpperCase();
@@ -19,9 +19,18 @@ function getEncodedWord(word: string): string | null {
 	return encoded.join("-");
 }
 
+type AchievementNames = "codebreaker" | "captaincodebreaker";
+
 class ElgyemsNumberEncoder extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"codebreaker": {name: "Codebreaker", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captaincodebreaker": {name: "Captain Codebreaker", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = ElgyemsNumberEncoder.achievements.codebreaker;
+	allAnswersTeamAchievement = ElgyemsNumberEncoder.achievements.captaincodebreaker;
 	roundTime: number = 30 * 1000;
 
 	static async loadData(): Promise<void> { // eslint-disable-line @typescript-eslint/require-await

--- a/src/games/grumpigs-pokemath.ts
+++ b/src/games/grumpigs-pokemath.ts
@@ -1,5 +1,5 @@
 import { assertStrictEqual } from "../test/test-tools";
-import type { GameFileTests, IGameFile } from "../types/games";
+import type { GameFileTests, IGameAchievement, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
 type Operation = 'add' | 'subtract' | 'multiply' | 'divide';
@@ -13,10 +13,19 @@ const OPERATION_SYMBOLS: KeyedDict<Operation, string> = {
 	'divide': '/',
 };
 
+type AchievementNames = "mathlete" | "captainmathlete";
+
 class GrumpigsPokemath extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"mathlete": {name: "Mathlete", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainmathlete": {name: "Captain Mathlete", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static pokemonByNumber: Dict<string[]> = {};
 	static highestPokedexNumber: number = 0;
 
+	allAnswersAchievement = GrumpigsPokemath.achievements.mathlete;
+	allAnswersTeamAchievement = GrumpigsPokemath.achievements.captainmathlete;
 	lastOperation: Operation = 'divide';
 	lastResult: number = 0;
 	roundTime = 30 * 1000;

--- a/src/games/gyarados-shiny-hunting.ts
+++ b/src/games/gyarados-shiny-hunting.ts
@@ -1,6 +1,6 @@
 import type { Player } from "../room-activity";
 import type { ModelGeneration, IGifDirectionData } from "../types/dex";
-import type { IGameFile } from "../types/games";
+import type { IGameAchievement, IGameFile } from "../types/games";
 import type { IPokemon } from "../types/pokemon-showdown";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from "./templates/question-and-answer";
 
@@ -21,9 +21,19 @@ const SPRITE_GENERATION: ModelGeneration = 'bw';
 const ANSWER_COMMAND = 'hunt';
 const LETTERS = Tools.letters.toUpperCase().split("");
 
+type AchievementNames = "shinebrightlikeadiamond" | "captainshinebright";
+
 class GyaradosShinyHunting extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"shinebrightlikeadiamond": {name: "Shine Bright Like a Diamond", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainshinebright": {name: "Captain Shinebright", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static gifData: Dict<IGifDirectionData> = {};
 	static gifDataKeys: string[] = [];
+
+	allAnswersAchievement = GyaradosShinyHunting.achievements.shinebrightlikeadiamond;
+	allAnswersTeamAchievement = GyaradosShinyHunting.achievements.captainshinebright;
 
 	answerCommands: string[] = [ANSWER_COMMAND];
 	cooldownBetweenRounds: number = 5 * 1000;

--- a/src/games/hitmonchans-hangman.ts
+++ b/src/games/hitmonchans-hangman.ts
@@ -1,12 +1,21 @@
 import type { Player } from "../room-activity";
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from "./templates/question-and-answer";
 
 const MIN_LETTERS = 3;
 
+type AchievementNames = "savedtheman" | "captainmansaver";
+
 class HitmonchansHangman extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"savedtheman": {name: "Saved the Man", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainmansaver": {name: "Captain Man Saver", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = HitmonchansHangman.achievements.savedtheman;
+	allAnswersTeamAchievement = HitmonchansHangman.achievements.captainmansaver;
 	allLetters: number = 0;
 	currentCategory: string = '';
 	guessedLetters: string[] = [];

--- a/src/games/hypnos-hunches.ts
+++ b/src/games/hypnos-hunches.ts
@@ -1,12 +1,21 @@
 import type { Player } from "../room-activity";
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from "./templates/question-and-answer";
 
 const MIN_LETTERS = 3;
 
+type AchievementNames = "hunchback" | "captainhunchback";
+
 class HypnosHunches extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"hunchback": {name: "Hunchback", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainhunchback": {name: "Captain Hunchback", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = HypnosHunches.achievements.hunchback;
+	allAnswersTeamAchievement = HypnosHunches.achievements.captainhunchback;
 	currentCategory: string = '';
 	guessLimit: number = 10;
 	guessedLetters: string[] = [];

--- a/src/games/jirachis-coloring-adventure.ts
+++ b/src/games/jirachis-coloring-adventure.ts
@@ -1,9 +1,19 @@
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
+type AchievementNames = "rainbowdash" | "captainrainbowdash";
+
 class JirachisColoringAdventure extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"rainbowdash": {name: "Rainbow Dash", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainrainbowdash": {name: "Captain Rainbow Dash", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = JirachisColoringAdventure.achievements.rainbowdash;
+	allAnswersTeamAchievement = JirachisColoringAdventure.achievements.captainrainbowdash;
+	
 	static async loadData(): Promise<void> { // eslint-disable-line @typescript-eslint/require-await
 		const hints: Dict<string[]> = {};
 		const hintKeys: string[] = [];

--- a/src/games/lanturns-illuminated-letters.ts
+++ b/src/games/lanturns-illuminated-letters.ts
@@ -1,5 +1,5 @@
 import type { Player } from "../room-activity";
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import type { IHexCodeData } from "../types/tools";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
@@ -7,9 +7,18 @@ const BANNED_CHARACTERS: string[] = ['.', '-', '(', ')'];
 const LETTERS_TO_REVEAL = 3;
 const MINIMUM_LENGTH = LETTERS_TO_REVEAL * 2;
 
+type AchievementNames = "lightspeed" | "captainlightspeed";
+
 class LanturnsIlluminatedLetters extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"lightspeed": {name: "Lightspeed", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainlightspeed": {name: "Captain Lightspeed", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = LanturnsIlluminatedLetters.achievements.lightspeed;
+	allAnswersTeamAchievement = LanturnsIlluminatedLetters.achievements.captainlightspeed;
 	currentCategory: string = '';
 	currentIndicies: number[] = [];
 	hiddenColor: IHexCodeData = Tools.getNamedHexCode("Black");

--- a/src/games/lugias-obstructive-letters.ts
+++ b/src/games/lugias-obstructive-letters.ts
@@ -1,4 +1,4 @@
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
 const BASE_POINTS = 50;
@@ -15,10 +15,19 @@ function getAvailableLetters(id: string): string[] {
 	return availableLetters;
 }
 
+type AchievementNames = "roadblockremover" | "captainroadblockremover";
+
 class LugiasObstructiveLetters extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"roadblockremover": {name: "Roadblock Remover", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainroadblockremover": {name: "Captain Roadblock Remover", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static availableLetters: Dict<string[]> = {};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = LugiasObstructiveLetters.achievements.roadblockremover;
+	allAnswersTeamAchievement = LugiasObstructiveLetters.achievements.captainroadblockremover;
 	currentCategory: string = '';
 	loserPointsToBits: number = 2;
 	roundTime: number = 30 * 1000;

--- a/src/games/magnetons-mashups.ts
+++ b/src/games/magnetons-mashups.ts
@@ -1,11 +1,20 @@
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
 const BASE_NUMBER_OF_NAMES = 2;
 
+type AchievementNames = "monstermash" | "captainmonstermash";
+
 class MagnetonsMashups extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"monstermash": {name: "Monster Mash", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainmonstermash": {name: "Captain Monster Mash", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = MagnetonsMashups. achievements.monstermash;
+	allAnswersTeamAchievement = MagnetonsMashups.achievements.captainmonstermash;
 	currentCategory: string = '';
 	roundTime: number = 30 * 1000;
 

--- a/src/games/malamars-bowls.ts
+++ b/src/games/malamars-bowls.ts
@@ -1,5 +1,5 @@
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
-import type { IGameFile } from "../types/games";
+import type { IGameAchievement, IGameFile } from "../types/games";
 import type { IParam, IParametersThreadData } from './../workers/parameters';
 import type { Player } from '../room-activity';
 
@@ -14,7 +14,14 @@ const paramTypeDexesKeys: Dict<Dict<KeyedDict<ParamType, string[]>>> = {};
 
 const searchTypes: (keyof IParametersThreadData)[] = ['pokemon'];
 
+type AchievementNames = "bowledover";
+
 class MalamarsBowls extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"bowledover": {name: "Bowled Over", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+	};
+	
+	allAnswersAchievement = MalamarsBowls.achievements.bowledover;
 	bowlsRound: number = 0;
 	hintUpdates: number = 0;
 	multiRoundHints = true;

--- a/src/games/mareanies-marquees.ts
+++ b/src/games/mareanies-marquees.ts
@@ -1,11 +1,20 @@
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
 const LETTERS_TO_REVEAL = 4;
 
+type AchievementNames = "checkmarq" | "captaincheckmarq";
+
 class MareaniesMarquees extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"checkmarq": {name: "Check Marq", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captaincheckmarq": {name: "Captain Check Marq", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = MareaniesMarquees.achievements.checkmarq;
+	allAnswersTeamAchievement = MareaniesMarquees.achievements.captaincheckmarq;
 	currentCategory: string = '';
 	currentIndex: number = -1;
 	hintUpdates: number = 0;

--- a/src/games/mudbrays-one-aways.ts
+++ b/src/games/mudbrays-one-aways.ts
@@ -1,4 +1,4 @@
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
 const upperCaseLetters: readonly string[] = Tools.lettersArray.map(x => x.toUpperCase());
@@ -39,9 +39,18 @@ function getOneAways(word: string): string[] | null {
 	return [oneAways[0].join(""), oneAways[1].join("")];
 }
 
+type AchievementNames = "ciphersolver" | "captainciphersolver";
+
 class MudbraysOneAways extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"ciphersolver": {name: "Cipher Solver", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainciphersolver": {name: "Captain Cipher Solver", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = MudbraysOneAways.achievements.ciphersolver;
+	allAnswersTeamAchievement = MudbraysOneAways.achievements.captainciphersolver;
 	roundTime: number = 30 * 1000;
 
 	static async loadData(): Promise<void> { // eslint-disable-line @typescript-eslint/require-await

--- a/src/games/natus-nature-minmax.ts
+++ b/src/games/natus-nature-minmax.ts
@@ -1,11 +1,20 @@
 import type { Player } from "../room-activity";
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import type { INature, StatIDExceptHP } from "../types/pokemon-showdown";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
+type AchievementNames = "naturescalling" | "captainnature";
+
 class NatusNatureMinMax extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"naturescalling": {name: "Nature's Calling", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainnature": {name: "Captain Nature", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = NatusNatureMinMax. achievements.naturescalling;
+	allAnswersTeamAchievement = NatusNatureMinMax.achievements.captainnature;
 	hintPrefix: string = "Randomly generated Pokemon";
 	oneGuessPerHint = true;
 	roundTime: number = 30 * 1000;

--- a/src/games/poliwraths-portmanteaus.ts
+++ b/src/games/poliwraths-portmanteaus.ts
@@ -1,12 +1,22 @@
 import type { PRNGSeed } from "../lib/prng";
 import { PRNG } from "../lib/prng";
-import type { GameFileTests, IGameFile } from "../types/games";
+import type { GameFileTests, IGameAchievement, IGameFile } from "../types/games";
 import type { PoolType } from './../workers/portmanteaus';
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
 const BASE_NUMBER_OF_PORTS = 2;
 
+type AchievementNames = "opportunist" | "captainopportunist";
+
 export class PoliwrathsPortmanteaus extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"opportunist": {name: "OP Portunist", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainopportunist": {name: "Captain OP Portunist", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
+
+	allAnswersAchievement = PoliwrathsPortmanteaus.achievements.opportunist;
+	allAnswersTeamAchievement = PoliwrathsPortmanteaus.achievements.captainopportunist;
 	answerParts: Dict<string[]> = {};
 	customPortCategories: string[] | null = null;
 	customPortDetails: string[] | null = null;

--- a/src/games/porygons-movesearch-match.ts
+++ b/src/games/porygons-movesearch-match.ts
@@ -1,9 +1,18 @@
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
+type AchievementNames = "movesetmaster" | "captainmovesetmaster";
+
 class PorygonsMovesearchMatch extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"movesetmaster": {name: "Moveset Master", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainmovesetmaster": {name: "Captain Moveset Master", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
 
+	allAnswersAchievement = PorygonsMovesearchMatch. achievements.movesetmaster;
+	allAnswersTeamAchievement = PorygonsMovesearchMatch.achievements.captainmovesetmaster;
 	hintPrefix: string = "Randomly generated moveset";
 	roundTime: number = 20 * 1000;
 

--- a/src/games/silvallys-unique-pairs.ts
+++ b/src/games/silvallys-unique-pairs.ts
@@ -1,8 +1,18 @@
-import type { IGameCachedData, IGameFile } from "../types/games";
+import type { IGameAchievement, IGameCachedData, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
+type AchievementNames = "oneofakind" | "captainoneofakind";
+
 class SilvallysUniquePairs extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"oneofakind": {name: "One of a Kind", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captainoneofakind": {name: "Captain One of a Kind", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static cachedData: IGameCachedData = {};
+
+	allAnswersAchievement = SilvallysUniquePairs.achievements.oneofakind;
+	allAnswersTeamAchievement = SilvallysUniquePairs.achievements.captainoneofakind;
 	roundTime: number = 5 * 60 * 1000;
 	hintPrefix: string = "Silvally wants a unique pair for";
 

--- a/src/games/wailords-egg-compatibilities.ts
+++ b/src/games/wailords-egg-compatibilities.ts
@@ -1,14 +1,23 @@
-import type { IGameFile } from "../types/games";
+import type { IGameAchievement, IGameFile } from "../types/games";
 import { game as questionAndAnswerGame, QuestionAndAnswer } from './templates/question-and-answer';
 
 const BASE_MIDDLE_EGG_GROUPS = 1;
 
+type AchievementNames = "cupid" | "captaincupid";
+
 class WailordsEggCompatibilities extends QuestionAndAnswer {
+	static achievements: KeyedDict<AchievementNames, IGameAchievement> = {
+		"cupid": {name: "Cupid", type: 'all-answers', bits: 1000, description: "get every answer in one game"},
+		"captaincupid": {name: "Captain Cupid", type: 'all-answers-team', bits: 1000, mode: 'collectiveteam', 
+			description: "get every answer for your team and win the game"},
+	};
 	static pokemonEggGroups: Dict<DeepImmutableArray<string>> = {};
 	static eggGroups: Dict<string[]> = {};
 	static eggGroupKeys: string[] = [];
 	static pokemonKeys: string[] = [];
 
+	allAnswersAchievement = WailordsEggCompatibilities.achievements.cupid;
+	allAnswersTeamAchievement = WailordsEggCompatibilities.achievements.captaincupid;
 	lastStartEggGroup: string = "";
 	lastEndEggGroup: string = "";
 	lastStartPokemon: string = "";


### PR DESCRIPTION
the following games are all QuestionAndAnswer type. the solo and team achievements i'm adding for these are all the same type: Get every answer in one game (type: 'all-answers' )

- Ambipoms tossups
  - (Captain) Untossable
- Azelfs alliteration
  - Adept (Captain) Alliterator 
- Chimechos stat school
  - First (Captain) Statesman
- Deoxys differences
  - Deoxys (Captain) Speed
- Eevees evolutionary lines
  - (Captain) Darwinner
- Elgyems number encoder
  - (Captain) Codebreaker
- Grumpigs pokemath
  - (Captain) Mathlete
- Gyarados' shiny hunting
  - Shine Bright Like a Diamond; Captain Shinebright
- Hitmonchans hangman
  - Saved the Man; Captain Man Saver (honestly hate this name) 
- Hypnos hunches
  - (Captain) Hunchback
- Jirachis Color Adventure
  - (Captain) Rainbow Dash
- Lanturns illuminated letters
  - (Captain) Lightspeed
- Lugias obstructive letters
  - (Captain) Roadblock Remover
- Magnetons mashups
  - (Captain) Monster Mash
- Malamars bowls
  -  Bowled Over 
- Mareanies marquees
  - (Captain) Check Marq
- Mudbrays one aways
  - (Captain) Cipher Solver
- Natus nature minmax
  - Nature's Calling; Captain Nature
- Poliwraths portmanteaus
  - (Captain) OP Portunist
- Porygons movesearch match
  - (Captain) Moveset Master
- Silvallys unique pairs
  - (Captain) One of a Kind
- Wailords egg compatibilities
  - (Captain) Cupid

all these names are gathered from the chieves workshop from a couple of years ago: 
https://docs.google.com/document/d/1pHN3DW4DxV4Em3BBMXvnhJciL6fIsvxIhZLvJxAL7wU/edit